### PR TITLE
Add Rails 4 compatibility

### DIFF
--- a/lib/plain_old_model/base.rb
+++ b/lib/plain_old_model/base.rb
@@ -1,7 +1,4 @@
-require 'active_model/naming'
-require 'active_model/translation'
-require 'active_model/validations'
-require 'active_model/conversion'
+require 'active_model'
 require 'plain_old_model/attribute_assignment'
 
 module PlainOldModel


### PR DESCRIPTION
In ActiveModel 4, you can no longer require portions of ActiveModel, and instead must require all.

See https://github.com/rails/rails/issues/5768

This is not a breaking change (at least, tests pass on both 3.2.22 and 4.x.x, and it seems hard to think of an issue this would cause).