### PR TITLE
Address rspec deprecation warnings

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ require 'plain_old_model/version'
 
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
+  config.expect_with(:rspec) { |c| c.syntax = :should }
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
- `treat_symbols_as_metadata_keys_with_true_values` is always true now
- Should syntax is deprecated and will be removed in Rspec 4.x

I am more than happy to replace the `should` syntax with `expect`s, but that is not consistent with the other gems that I've seen at Getty and I respect the concision argument.

That being said, this is a public gem and most gems I've seen are going with Rspec's move to the expect syntax. This, at least, makes it clear that we intend to stick with `should`.
